### PR TITLE
add agencyId query param to every request

### DIFF
--- a/src/campaign_api_client.py
+++ b/src/campaign_api_client.py
@@ -180,7 +180,7 @@ class CampaignApiClient:
             response = requests.post(url, auth=(self.user, self.password), data=json.dumps(
                 body), headers=self.headers, params=params)
         except Exception as ex:
-            logger.info(ex)
+            logger.error(ex)
             sys.exit()
         if response.status_code not in [200, 201]:
             raise Exception(
@@ -196,7 +196,7 @@ class CampaignApiClient:
             response = requests.get(url, params=params, auth=(
                 self.user, self.password), headers=headers)
         except Exception as ex:
-            logger.info(ex)
+            logger.error(ex)
             sys.exit()
         if response.status_code not in [200, 201]:
             raise Exception(

--- a/src/campaign_api_client.py
+++ b/src/campaign_api_client.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 
+from src import *
 from enum import Enum
 import argparse
 import requests
 
 import sys
 sys.path.append('../')
-from src import *
 
 logger = logging.getLogger(__name__)
 
@@ -14,17 +14,17 @@ logger = logging.getLogger(__name__)
 class Routes:
     SYSTEM_REPORT = '/system'
     SYNC_FEED = '/%s/v101/sync/feeds'
-    SYNC_SUBSCRIPTIONS = '/%s/v101/sync/subscriptions?aid=%s'
+    SYNC_SUBSCRIPTIONS = '/%s/v101/sync/subscriptions'
     SYNC_SESSIONS = '/%s/v101/sync/sessions'
 
     # First parameter is Session ID. Second parameter is Command Type
-    SYNC_SESSION_COMMAND = '/%s/v101/sync/sessions/%s/commands/%s?aid=%s'
+    SYNC_SESSION_COMMAND = '/%s/v101/sync/sessions/%s/commands/%s'
 
     # First parameter is Subscription ID. Second parameter is Command Type
-    SYNC_SUBSCRIPTION_COMMAND = '/%s/v101/sync/subscriptions/%s/commands/%s?aid=%s'
+    SYNC_SUBSCRIPTION_COMMAND = '/%s/v101/sync/subscriptions/%s/commands/%s'
 
     # Parameter is the Subscription ID
-    FETCH_SUBSCRIPTION = '/%/v101/sync/subscriptions/%s'
+    FETCH_SUBSCRIPTION = '/%s/v101/sync/subscriptions/%s'
 
     # First parameter is the Root Filing NID
     FETCH_FILING = '/cal/v101/filings/%s'
@@ -38,7 +38,8 @@ class Routes:
 
 class CampaignApiClient:
     """Provides support for synchronizing local database with Campaign API filing data"""
-    def __init__(self, base_url, api_key, api_password):
+
+    def __init__(self, base_url, api_key, api_password, agency_id):
         self.headers = {
             'Content-type': 'application/json',
             'Accept': 'application/json'
@@ -46,6 +47,7 @@ class CampaignApiClient:
         self.base_url = base_url
         self.user = api_key
         self.password = api_password
+        self.agency_id = agency_id
 
     def fetch_system_report(self):
         logger.debug('Checking to verify the Campaign API system is ready')
@@ -57,13 +59,20 @@ class CampaignApiClient:
             logger.debug('\tComponent Name: %s', comp['name'])
             logger.debug('\tComponent Message: %s', comp['message'])
             logger.debug('\tComponent status: %s', comp['status'])
-            logger.debug('\tComponent Build DateTime: %s', comp['buildDateTime'])
+            logger.debug('\tComponent Build DateTime: %s',
+                         comp['buildDateTime'])
             logger.debug('\tComponent Build Version: %s', comp['buildVersion'])
         return sr
 
-    def create_subscription(self, domain, agency_id, feed_name_arg, subscription_name_arg):
+    def peek_subscription(self, domain, sub_id):
+        logger.debug(f"Peeking SyncSubscription with id: {sub_id}")
+        ext = Routes.FETCH_SUBSCRIPTION % (domain, sub_id)
+        url = self.base_url + ext + '/peek'
+        return self.get_http_request(url)
+
+    def create_subscription(self, domain, feed_name_arg, subscription_name_arg):
         logger.debug('Creating a SyncSubscription')
-        url = self.base_url + Routes.SYNC_SUBSCRIPTIONS % (domain, agency_id)
+        url = self.base_url + Routes.SYNC_SUBSCRIPTIONS % (domain)
         body = {
             'feedName': feed_name_arg,
             'name': subscription_name_arg
@@ -72,42 +81,48 @@ class CampaignApiClient:
 
     def fetch_subscription(self, domain, sub_id):
         logger.debug(f"Fetching SyncSubscription with id: {sub_id}")
-        ext = Routes.SYNC_SUBSCRIPTION_COMMAND % (domain, sub_id)
+        ext = Routes.FETCH_SUBSCRIPTION % (domain, sub_id)
         url = self.base_url + ext
         return self.get_http_request(url)
 
-    def execute_subscription_command(self, domain, agency_id, sub_id, subscription_command_type):
-        logger.debug(f"Executing {subscription_command_type} SyncSubscription command")
-        ext = Routes.SYNC_SUBSCRIPTION_COMMAND % (domain, sub_id, subscription_command_type, agency_id)
+    def execute_subscription_command(self, domain, sub_id, subscription_command_type):
+        logger.debug(
+            f"Executing {subscription_command_type} SyncSubscription command")
+        ext = Routes.SYNC_SUBSCRIPTION_COMMAND % (
+            domain, sub_id, subscription_command_type)
         url = self.base_url + ext
         body = {
             'id': sub_id
         }
         return self.post_http_request(url, body)
 
-    def query_subscriptions(self, domain, agency_id, feed_id, limit=1000, offset=0):
+    def query_subscriptions(self, domain, feed_id, limit=1000, offset=0):
         logger.debug('Retrieving available subscriptions\n')
-        params = {'feedId': feed_id, 'status': 'Active', 'limit': limit, 'offset': offset}
-        url = self.base_url + Routes.SYNC_SUBSCRIPTIONS % (domain, agency_id)
+        params = {'feedId': feed_id, 'status': 'Active',
+                  'limit': limit, 'offset': offset}
+        url = self.base_url + Routes.SYNC_SUBSCRIPTIONS % domain
         return self.get_http_request(url, params)
 
-    def create_session(self, domain, agency_id, sub_id):
+    def create_session(self, domain, sub_id):
         logger.debug(f'Creating a SyncSession using SyncSubscription {sub_id}')
-        url = f'{self.base_url}/{Routes.SYNC_SESSIONS % domain}?aid={agency_id}'
+        url = f'{self.base_url}/{Routes.SYNC_SESSIONS % domain}'
         body = {
             'subscriptionId': sub_id
         }
         return self.post_http_request(url, body)
 
-    def execute_session_command(self, domain, agency_id, session_id, session_command_type):
+    def execute_session_command(self, domain, session_id, session_command_type):
         logger.debug(f'Executing {session_command_type} SyncSession command')
-        url = self.base_url + Routes.SYNC_SESSION_COMMAND % (domain, session_id, session_command_type, agency_id)
+        url = self.base_url + \
+            Routes.SYNC_SESSION_COMMAND % (
+                domain, session_id, session_command_type)
         return self.post_http_request(url)
 
-    def fetch_sync_topic(self, domain, agency_id, session_id, topic, limit=1000, offset=0):
-        logger.debug(f'Fetching {topic} topic: offset={offset}, limit={limit}\n')
+    def fetch_sync_topic(self, domain, session_id, topic, limit=1000, offset=0):
+        logger.debug(
+            f'Fetching {topic} topic: offset={offset}, limit={limit}\n')
         params = {'limit': limit, 'offset': offset}
-        url = f'{self.base_url}/{Routes.SYNC_SESSIONS % domain}/{session_id}/{topic}?aid={agency_id}'
+        url = f'{self.base_url}/{Routes.SYNC_SESSIONS % domain}/{session_id}/{topic}'
         return self.get_http_request(url, params)
 
     def retrieve_sync_feeds(self, domain):
@@ -150,7 +165,8 @@ class CampaignApiClient:
         logger.debug('Fetching Efile Content')
         url = self.base_url + Routes.FETCH_EFILE_CONTENT % root_filing_nid
         logger.debug(f'Making GET HTTP request to {url}')
-        response = requests.get(url, params={'contentType': 'efile'}, auth=(self.user, self.password), headers=self.headers)
+        response = requests.get(url, params={'contentType': 'efile'}, auth=(
+            self.user, self.password), headers=self.headers)
         if response.status_code not in [200, 201]:
             raise Exception(
                 f'Error requesting Url: {url}, Response code: {response.status_code}. Error Message: {response.text}')
@@ -160,7 +176,9 @@ class CampaignApiClient:
     def post_http_request(self, url, body=None):
         logger.debug(f'Making POST HTTP request to {url}')
         try:
-            response = requests.post(url, auth=(self.user, self.password), data=json.dumps(body), headers=self.headers)
+            params = {'aid': self.agency_id}
+            response = requests.post(url, auth=(self.user, self.password), data=json.dumps(
+                body), headers=self.headers, params=params)
         except Exception as ex:
             logger.info(ex)
             sys.exit()
@@ -169,12 +187,14 @@ class CampaignApiClient:
                 f'Error requesting Url: {url}, Response code: {response.status_code}. Error Message: {response.text}')
         return response.json()
 
-    def get_http_request(self, url, params=None, headers=None):
+    def get_http_request(self, url, params={}, headers=None):
         logger.debug(f'Making GET HTTP request to {url}')
+        params['aid'] = self.agency_id
         if headers is None:
             headers = self.headers
         try:
-            response = requests.get(url, params=params, auth=(self.user, self.password), headers=headers)
+            response = requests.get(url, params=params, auth=(
+                self.user, self.password), headers=headers)
         except Exception as ex:
             logger.info(ex)
             sys.exit()
@@ -183,11 +203,12 @@ class CampaignApiClient:
                 f'Error requesting Url: {url}, Response code: {response.status_code}. Error Message: {response.text}')
         return response.json()
 
-    def sync_topic(self, domain, agency_id, session_id, topic_name, page_size):
+    def sync_topic(self, domain, session_id, topic_name, page_size):
         offset = 0
         has_next_page = True
         while has_next_page:
-            qr = self.fetch_sync_topic(domain, agency_id, session_id, topic_name, page_size, offset)
+            qr = self.fetch_sync_topic(
+                domain, session_id, topic_name, page_size, offset)
             has_next_page = qr['hasNextPage']
             offset = offset + page_size
 
@@ -218,23 +239,27 @@ class SyncSessionCommandType(Enum):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Process Campaign API Sync Requests')
+    parser = argparse.ArgumentParser(
+        description='Process Campaign API Sync Requests')
     parser.add_argument('--sync-topics', nargs=1, metavar='Comma Separated List of Topics',
                         help='Find existing active subscription, or create new one, and sync topics')
 
     args = parser.parse_args()
 
     # First make sure that the Campaign API is ready
-    campaign_api_client = CampaignApiClient(api_url, api_key, api_password)
-    sys_report = campaign_api_client.fetch_system_report()
     default_domain = 'cal'
     default_agency_id = 'SFO'
+    campaign_api_client = CampaignApiClient(
+        api_url, api_key, api_password, default_agency_id)
+    sys_report = campaign_api_client.fetch_system_report()
     try:
         if sys_report['generalStatus'].lower() != 'ready':
-            logger.error('The Campaign API is not ready, current status is %s', sys_report['generalStatus'])
+            logger.error(
+                'The Campaign API is not ready, current status is %s', sys_report['generalStatus'])
             sys.exit()
         if args.sync_topics:
-            logger.info('Subscribe and sync Filing Activities and Element Activities')
+            logger.info(
+                'Subscribe and sync Filing Activities and Element Activities')
 
             # Create SyncSubscription or use existing SyncSubscription
             subscription_name = "My Sync Subscription"
@@ -244,8 +269,10 @@ if __name__ == '__main__':
             try:
                 # Create SyncSubscription or use existing SyncSubscription with feed specified
                 if not cal_subscription_id:
-                    logger.info('Creating new subscription with name "%s" and feed name "%s"', subscription_name, feed_name)
-                    subscription_response = campaign_api_client.create_subscription(default_domain, default_agency_id, feed_name, subscription_name)
+                    logger.info(
+                        'Creating new subscription with name "%s" and feed name "%s"', subscription_name, feed_name)
+                    subscription_response = campaign_api_client.create_subscription(
+                        default_domain, feed_name, subscription_name)
                     subscription = subscription_response['subscription']
                     sub_id = subscription['id']
 
@@ -256,7 +283,8 @@ if __name__ == '__main__':
 
                 # Create SyncSession
                 logger.info('Creating sync session')
-                sync_session_response = campaign_api_client.create_session(default_domain, default_agency_id, sub_id)
+                sync_session_response = campaign_api_client.create_session(
+                    default_domain, sub_id)
                 if sync_session_response['syncDataAvailable']:
                     sync_session = sync_session_response['session']
                     sess_id = sync_session['id']
@@ -267,18 +295,22 @@ if __name__ == '__main__':
                         page_size = 1000
                         logger.info(f'Synchronizing {topic}')
                         session_id = sync_session['id']
-                        campaign_api_client.sync_topic(default_domain, default_agency_id, session_id, topic, page_size)
+                        campaign_api_client.sync_topic(
+                            default_domain, session_id, topic, page_size)
 
                     # Complete SyncSession
                     logger.info('Completing session')
-                    campaign_api_client.execute_session_command(default_domain, default_agency_id, sess_id, SyncSessionCommandType.Complete.name)
+                    campaign_api_client.execute_session_command(
+                        default_domain, sess_id, SyncSessionCommandType.Complete.name)
                     logger.info('Sync complete')
                 else:
-                    logger.info('The Campaign API system has no sync data available')
+                    logger.info(
+                        'The Campaign API system has no sync data available')
             except Exception as ex:
                 # Cancel Session on error
                 if sync_session is not None:
-                    campaign_api_client.execute_session_command(default_domain, default_agency_id, sync_session.id, SyncSessionCommandType.Cancel.name)
+                    campaign_api_client.execute_session_command(
+                        default_domain, sync_session.id, SyncSessionCommandType.Cancel.name)
                 logger.error('Error attempting to sync: %s', ex)
                 sys.exit()
     except Exception as ex:

--- a/src/campaign_api_main.py
+++ b/src/campaign_api_main.py
@@ -27,7 +27,8 @@ def main():
     agency_id = 'SFO'
     try:
         logger.info(f'Starting {domain} Campaign API synchronization lifecycle for Agency {agency_id}')
-        api_client = CampaignApiClient(api_url, api_key, api_password)
+        api_client = CampaignApiClient(
+            api_url, api_key, api_password, agency_id)
 
         # Verify the system is ready
         sys_report = api_client.fetch_system_report()
@@ -39,7 +40,7 @@ def main():
             feed_name = 'cal_v101'
             if not cal_subscription_id:
                 logger.info('Creating new subscription with name "%s" and feed name "%s"', name, feed_name)
-                subscription_response = api_client.create_subscription(domain, agency_id, feed_name, name)
+                subscription_response = api_client.create_subscription(domain, feed_name, name)
                 subscription = subscription_response['subscription']
                 sub_id = subscription['id']
 
@@ -50,7 +51,7 @@ def main():
 
             # Create SyncSession
             logger.info('Creating sync session')
-            sync_session_response = api_client.create_session(domain, agency_id, sub_id)
+            sync_session_response = api_client.create_session(domain, sub_id)
             if sync_session_response['syncDataAvailable']:
                 # Sync all available topics
                 for topic in ['filing-activities', 'element-activities', 'transaction-activities', 'unitemized-transaction-activities']:
@@ -59,16 +60,16 @@ def main():
                     logger.info(f'Synchronizing {topic}')
                     sync_session = sync_session_response['session']
                     session_id = sync_session['id']
-                    query_results = api_client.fetch_sync_topic(domain, agency_id, session_id, topic, page_size, offset)
+                    query_results = api_client.fetch_sync_topic(domain, session_id, topic, page_size, offset)
                     print_query_results(query_results)
                     while query_results['hasNextPage']:
                         offset = offset + page_size
-                        query_results = api_client.fetch_sync_topic(domain, agency_id, session_id, topic, page_size, offset)
+                        query_results = api_client.fetch_sync_topic(domain, session_id, topic, page_size, offset)
                         print_query_results(query_results)
 
                 # Complete SyncSession
                 logger.info('Completing sync session')
-                api_client.execute_session_command(domain, agency_id, session_id, SyncSessionCommandType.Complete.name)
+                api_client.execute_session_command(domain, session_id, SyncSessionCommandType.Complete.name)
 
                 logger.info('Synchronization lifecycle complete\n\n')
             else:
@@ -79,7 +80,7 @@ def main():
         # Cancel Session on error
         if sync_session is not None:
             logger.info('Error occurred, canceling sync session')
-            api_client.execute_session_command(domain, agency_id, sync_session.id, SyncSessionCommandType.Cancel.name)
+            api_client.execute_session_command(domain, sync_session.id, SyncSessionCommandType.Cancel.name)
         logger.error('Error running CampaignApiClient: %s', ex)
 
     """
@@ -95,7 +96,8 @@ def main():
     domain = 'Global'
     try:
         logger.info(f'Starting {domain} Campaign API synchronization lifecycle for Agency {agency_id}')
-        api_client = CampaignApiClient(api_url, api_key, api_password)
+        api_client = CampaignApiClient(
+            api_url, api_key, api_password, agency_id)
 
         # Verify the system is ready
         sys_report = api_client.fetch_system_report()
@@ -107,7 +109,7 @@ def main():
             feed_name = 'global_geo_activity_v101'
             if not global_subscription_id:
                 logger.info('Creating new subscription with name "%s" and feed name "%s"', name, feed_name)
-                subscription_response = api_client.create_subscription(domain, agency_id, feed_name, name)
+                subscription_response = api_client.create_subscription(domain, feed_name, name)
                 subscription = subscription_response['subscription']
                 sub_id = subscription['id']
 
@@ -118,7 +120,7 @@ def main():
 
             # Create SyncSession
             logger.info('Creating sync session')
-            sync_session_response = api_client.create_session(domain, agency_id, sub_id)
+            sync_session_response = api_client.create_session(domain, sub_id)
             if sync_session_response['syncDataAvailable']:
                 # Sync all available topics
                 for topic in ['geocode-activities', 'link-activities']:
@@ -127,20 +129,20 @@ def main():
                     logger.info(f'Synchronizing {topic}')
                     sync_session = sync_session_response['session']
                     session_id = sync_session['id']
-                    query_results = api_client.fetch_sync_topic(domain, agency_id, session_id, topic, page_size, offset)
+                    query_results = api_client.fetch_sync_topic(domain, session_id, topic, page_size, offset)
                     print_query_results(query_results)
                     while query_results['hasNextPage']:
                         offset = offset + page_size
-                        query_results = api_client.fetch_sync_topic(domain, agency_id, session_id, topic, page_size, offset)
+                        query_results = api_client.fetch_sync_topic(domain, session_id, topic, page_size, offset)
                         print_query_results(query_results)
 
                 # Complete SyncSession
                 logger.info('Completing sync session')
-                api_client.execute_session_command(domain, agency_id, session_id, SyncSessionCommandType.Complete.name)
+                api_client.execute_session_command(domain, session_id, SyncSessionCommandType.Complete.name)
 
                 # Optionally, Cancel the subscription. Only done when no further use of subscription is required
                 logger.info('Canceling subscription')
-                api_client.execute_subscription_command(domain, agency_id, sub_id, SyncSessionCommandType.Cancel.name)
+                api_client.execute_subscription_command(domain, sub_id, SyncSessionCommandType.Cancel.name)
 
                 logger.info('Synchronization lifecycle complete')
             else:
@@ -151,7 +153,7 @@ def main():
         # Cancel Session on error
         if sync_session is not None:
             logger.info('Error occurred, canceling sync session')
-            api_client.execute_session_command(domain, agency_id, sync_session.id, SyncSessionCommandType.Cancel.name)
+            api_client.execute_session_command(domain, sync_session.id, SyncSessionCommandType.Cancel.name)
         logger.error('Error running CampaignApiClient: %s', ex)
     sys.exit()
 


### PR DESCRIPTION
adds agency_id as a class property of CampaignApiClient, then appends it to every api request made via `post_http_request()` and `get_http_request()`

this limits each Client instance to a single agency_id, which may or may not be desired

also adds method `peek_subscription()` which uses subscription peek endpoint to check for new data

